### PR TITLE
Enforce to upgrade installed packages for unmet dependencies

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@ class octo_base (
         logoutput => true,
     }
     exec { "upgrade installed packages":
-        command => "time -p /usr/bin/apt-get -y upgrade",
+        command => "time -p /usr/bin/apt-get -y upgrade --fix-missing",
         require => Exec["update apt repositories"],
         # Use a longer timeout as the default of 300 seconds fails more often than
         # we would like.


### PR DESCRIPTION
Puppet *`masterless`* is assumed to be installed as per a Puppet lab `.deb` package file ; dependencies on Ubuntu boxes may be unmet. This PR tries to address the failed upgrades of potential broken dependencies.