### PR TITLE
Try and avoid snapd purge problems

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,8 @@ class octo_base (
     # Remove unnecessary packages for Ubuntu 18:04 (see https://peteris.rocks/blog/can-you-kill-it/)
     $unnecessary_packages = [
       "snapd",
+      "ubuntu-core-launcher",
+      "squashfs-tools",
       "lvm2",
       "lxcfs",
       "accountsservice",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,9 +18,6 @@ class octo_base (
 
     # Remove unnecessary packages for Ubuntu 18:04 (see https://peteris.rocks/blog/can-you-kill-it/)
     $unnecessary_packages = [
-      "snapd",
-      "ubuntu-core-launcher",
-      "squashfs-tools",
       "lvm2",
       "lxcfs",
       "accountsservice",


### PR DESCRIPTION
By removing two other packages, via:
https://ubuntuforums.org/showthread.php?t=2328152

Problem symptoms:

    amazon-ebs: Removing snapd cache
    amazon-ebs: rm: cannot remove '/var/cache/snapd/aux': Is a directory
    amazon-ebs: dpkg: error processing package snapd (--purge):
    amazon-ebs:  installed snapd package post-removal script subprocess returned error exit status 1