### PR TITLE
Pass in region to cloudwatch logs puppet module as variable

### DIFF
--- a/manifests/cloudwatch/logs.pp
+++ b/manifests/cloudwatch/logs.pp
@@ -1,6 +1,6 @@
 class octo_base::cloudwatch::logs (
     $log_files,
-    $region = "eu-west-1"
+    $region
 ) {
     # Manifest to install the AWS logs agent
     # See http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/CWL_GettingStarted.html


### PR DESCRIPTION
Prior to this change, region was hardcoded to eu-west-1

This change sets region to be a variable that is passed in to the
module.