### PR TITLE
Fix puppet SSM installation

### DIFF
--- a/manifests/amazon_ssm_agent.pp
+++ b/manifests/amazon_ssm_agent.pp
@@ -14,16 +14,11 @@ class octo_base::amazon_ssm_agent {
       require => File['Download SSM agent'],
     }
 
-    file {'/tmp/amazon-ssm-agent.deb':
-      ensure  => absent,
-      require => Package['amazon-ssm-agent'],
-    }
-
     service { 'amazon-ssm-agent':
       ensure   => running,
       enable   => true,
       provider => 'systemd',
-      require => File['/tmp/amazon-ssm-agent.deb']
+      require => Package['amazon-ssm-agent']
     }
 }
 


### PR DESCRIPTION
Remove the unnecessary second `file` command which conflicts with the first.