### PR TITLE
Fixes for CIS server level 1 hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Puppet module providing common functionality for Octopus Energy machines.
 
 ## Changelog
 
+### v1.20
+
+- CIS Level 1 Server
+
 ### v1.19
 
 - Fix broken AWS inspector key

--- a/files/cis_hardening/etc/sysctl.d/limit_cores.conf
+++ b/files/cis_hardening/etc/sysctl.d/limit_cores.conf
@@ -1,0 +1,1 @@
+fs.suid_dumpable = 0

--- a/manifests/cis_hardening/skipped_tests.md
+++ b/manifests/cis_hardening/skipped_tests.md
@@ -56,3 +56,33 @@ We may look at this in the future. Our infrastructure is deployed regularly
 so the chance of any of these file systems filling up is minimal. Since we
 deploy with a single login user with passwordless sudo privileges we
 can't limit that users actions.
+
+## Internal firewall - Our network security is though AWS security groups
+* 3.6.5 Ensure firewall rules exist for all open ports
+
+## We don't run auditd - we should - these will be addressed
+* 4.1.3 Ensure auditing for processes that start prior to auditd is enabled
+* 4.1.4 Ensure events that modify date and time information are collected
+* 4.1.5 Ensure events that modify user/group information are collected
+* 4.1.6 Ensure events that modify the system's network environment are collected
+* 4.1.7 Ensure events that modify the system's Mandatory Access Controls are collected
+* 4.1.8 Ensure login and logout events are collected
+* 4.1.9 Ensure session initiation information is collected
+* 4.1.10 Ensure discretionary access control permission modification events are collected
+* 4.1.11 Ensure unsuccessful unauthorized file access attempts are collected
+* 4.1.12 Ensure use of privileged commands is collected
+* 4.1.13 Ensure successful file system mounts are collected
+* 4.1.14 Ensure file deletion events by users are collected
+* 4.1.15 Ensure changes to system administration scope (sudoers) is collected
+* 4.1.16 Ensure system administrator actions (sudolog) are collected
+* 4.1.17 Ensure kernel module loading and unloading is collected
+* 4.1.18 Ensure the audit configuration is immutable
+* 4.1.1.1 Ensure audit log storage size is configured
+* 4.1.1.2 Ensure system is disabled when audit logs are full
+* 4.1.1.3 Ensure audit logs are not automatically deleted
+* 4.2.4 Ensure permissions on all logfiles are configured
+
+## Only login is via SSH, which has equivalent restrictions in place
+ * 5.4.5 Ensure default user shell timeout is 900 seconds or less
+
+

--- a/manifests/cis_hardening/system.pp
+++ b/manifests/cis_hardening/system.pp
@@ -4,7 +4,7 @@ class octo_base::cis_hardening::system {
   file_line { "noexec /dev/shm":
     path => "/etc/fstab",
     line =>
-      "none     /run/shm     tmpfs     rw,noexec,nosuid,nodev     0     0",
+      "none     /dev/shm     tmpfs     rw,noexec,nosuid,nodev     0     0",
   }
 
   file { "disable unused filesystems":
@@ -14,10 +14,13 @@ class octo_base::cis_hardening::system {
   }
 
   # 1.5.1 Ensure core dumps are restricted
-  file { "limit core dumps":
-    path   => "/etc/security/limits.d/cores.conf",
+  file { "/etc/security/limits.d/cores.conf":
     source =>
       "puppet:///modules/octo_base/cis_hardening/etc/security/limits.d/cores.conf"
+  }
+  file { "/etc/sysctl.d/limit_cores.conf":
+    source =>
+      "puppet:///modules/octo_base/cis_hardening/etc/sysctl.d/limit_cores.conf"
   }
 
   # 1.5.3 Ensure address space layout randomization (ASLR) is enabled
@@ -140,6 +143,13 @@ class octo_base::cis_hardening::system {
     path  => "/etc/ssh/sshd_config",
     line  => "PermitRootLogin no",
     match => "#PermitRootLogin",
+  }
+
+  # 5.2.9 Ensure SSH PermitEmptyPasswords is disabled
+  file_line { "Ensure SSH PermitEmptyPasswords is disabled":
+    path  => "/etc/ssh/sshd_config",
+    line  => "PermitEmptyPasswords no",
+    match => "#PermitEmptyPasswords",
   }
 
   # 5.2.10 Ensure SSH PermitUserEnvironment is disabled

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,7 +33,7 @@ class octo_base (
 
     # Apply security patches for installed packages
     exec { "upgrade installed packages":
-        command => "time -p /usr/bin/apt-get -y upgrade --fix-missing --fix-broken",
+        command => "time -p /usr/bin/apt-get -y upgrade --fix-missing --fix-broken --autoremove",
         # Use a longer timeout as the default of 300 seconds fails more often than
         # we would like.
         timeout => 600,


### PR DESCRIPTION
We had a few tests fail that I thought had been fixed up to pass. This should address all of those and leave us with the need to set up and configure auditd to reach CIS level 2.