### PR TITLE
Bump version to v1.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Puppet module providing common functionality for Octopus Energy machines.
 
 ## Changelog
 
+### v1.27
+
+- Disable AWS Inspector in Vagrant builds
+
 ### v1.26
 
 - Set default umask to 027

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ Puppet module providing common functionality for Octopus Energy machines.
 
 - Exclude `/etc/cron.d/` from CIS permission tightening
 
-### v1.22
-
-- Exclude `/etc/cron.d/` from CIS permission tightening
-
 ### v1.21
 
 - Fix for sysctl not loading late enough in the boot sequence

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "octoenergy-octo_base",
-    "version": "1.26",
+    "version": "1.27",
     "author": "Octopus Energy",
     "license": "BSD",
     "summary": "Base machine functionality for Octopus Energy",


### PR DESCRIPTION
This just updated the changelog and the manifest.json so we can release a new version.

I am working on fixing the meter-points deployment (and part of that is refactoring the puppet code in there). To make that easier I want to run the code in Vagrant locally which isnt' currently possible without this fix.

Once this PR is merged I'll create the v1.27 tag on the merge commit.