### PR TITLE
Stop submitting metrics across Instance Name and ID dimensions

### DIFF
--- a/files/cloudwatch/metrics.json
+++ b/files/cloudwatch/metrics.json
@@ -15,10 +15,6 @@
         "MetricName": "SystemLoad",
         "Dimensions": [
             {
-                "Name": "InstanceId",
-                "Value": $INSTANCE_ID
-            },
-            {
                 "Name": "InstanceName",
                 "Value": $INSTANCE_NAME
             }
@@ -31,8 +27,8 @@
         "MetricName": "MemoryUsed",
         "Dimensions": [
             {
-                "Name": "InstanceId",
-                "Value": $INSTANCE_ID
+                "Name": "InstanceName",
+                "Value": $INSTANCE_NAME
             }
         ],
         "Timestamp": $TIMESTAMP,
@@ -42,10 +38,6 @@
     {
         "MetricName": "MemoryUsedPercentage",
         "Dimensions": [
-            {
-                "Name": "InstanceId",
-                "Value": $INSTANCE_ID
-            },
             {
                 "Name": "InstanceName",
                 "Value": $INSTANCE_NAME
@@ -59,8 +51,8 @@
         "MetricName": "MemoryFree",
         "Dimensions": [
             {
-                "Name": "InstanceId",
-                "Value": $INSTANCE_ID
+                "Name": "InstanceName",
+                "Value": $INSTANCE_NAME
             }
         ],
         "Timestamp": $TIMESTAMP,
@@ -71,8 +63,8 @@
         "MetricName": "SwapUsed",
         "Dimensions": [
             {
-                "Name": "InstanceId",
-                "Value": $INSTANCE_ID
+                "Name": "InstanceName",
+                "Value": $INSTANCE_NAME
             }
         ],
         "Timestamp": $TIMESTAMP,
@@ -82,10 +74,6 @@
     {
         "MetricName": "DiskUsedPercentage",
         "Dimensions": [
-            {
-                "Name": "InstanceId",
-                "Value": $INSTANCE_ID
-            },
             {
                 "Name": "InstanceName",
                 "Value": $INSTANCE_NAME
@@ -99,8 +87,8 @@
         "MetricName": "DiskUsed",
         "Dimensions": [
             {
-                "Name": "InstanceId",
-                "Value": $INSTANCE_ID
+                "Name": "InstanceName",
+                "Value": $INSTANCE_NAME
             }
         ],
         "Timestamp": $TIMESTAMP,
@@ -111,8 +99,8 @@
         "MetricName": "DiskAvailable",
         "Dimensions": [
             {
-                "Name": "InstanceId",
-                "Value": $INSTANCE_ID
+                "Name": "InstanceName",
+                "Value": $INSTANCE_NAME
             }
         ],
         "Timestamp": $TIMESTAMP,


### PR DESCRIPTION
Prior to this change, several metrics were submitted with both the `InstanceId` and `InstanceName` dimensions. This prevents us from analysing metrics only on the InstanceName dimension (which is the more interesting one) as the two dimensions are always grouped together.

![image](https://user-images.githubusercontent.com/80975/121660242-02c2e200-ca9b-11eb-98df-75e33921e05b.png)

This change stops including the `InstanceId` dimension as it's not that interesting and allow the metrics for dashboards to work correctly.