### PR TITLE
Add another DiskUsedPercentage cloudwatch metric with added dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Puppet module providing common functionality for Octopus Energy machines.
 
 ## Changelog
 
+### v1.33
+
+- Add another DiskUsedPercentage Cloudwatch metric with new dimensions
+
 ### v1.32
 
 - Ensure AWS Inspector installs on Ubuntu 20.04

--- a/files/cloudwatch/metrics.json
+++ b/files/cloudwatch/metrics.json
@@ -84,6 +84,22 @@
         "Unit": "Percent"
     },
     {
+        "MetricName": "DiskUsedPercentage",
+        "Dimensions": [
+            {
+                "Name": "InstanceName",
+                "Value": $INSTANCE_NAME
+            },
+            {
+                "Name": "InstanceId",
+                "Value": $INSTANCE_ID
+            }
+        ],
+        "Timestamp": $TIMESTAMP,
+        "Value": $DISK_USED_PERCENTAGE,
+        "Unit": "Percent"
+    },
+    {
         "MetricName": "DiskUsed",
         "Dimensions": [
             {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "octoenergy-octo_base",
-    "version": "1.32",
+    "version": "1.33",
     "author": "Octopus Energy",
     "license": "BSD",
     "summary": "Base machine functionality for Octopus Energy",


### PR DESCRIPTION
Instance ID was previously removed as a dimension from CloudWatch metrics to be able to analyse based only on Instance Name in [this commit](https://github.com/octoenergy/puppet-octo_base/commit/66c94b4de337f85f7fb18f3d8fe777c69fe9c0f2), but this prevents being able to monitor Disk Usage on individual instances with Datadog monitors - monitors of the same name are grouped together in alerts (e.g. [here](https://app.datadoghq.eu/monitors/5389854?groupsPerPage=25)).

Adding another DiskUsedPercentage metric with both dimensions InstanceName and InstanceID will mean that CloudWatch considers these as two separate metrics, and should allow DiskUsedPercentage to be analysed on both dimensions, or on instance name alone.

![image](https://user-images.githubusercontent.com/82942831/167671981-77c1340f-ad6e-4bb5-91d1-185229136157.png)


Ideally, the forecast monitor would be like [this](https://app.datadoghq.eu/monitors/5389855), with all instances included.