### PR TITLE
Fix metrics using CW Agent

### DIFF
--- a/manifests/cloudwatch/logs.pp
+++ b/manifests/cloudwatch/logs.pp
@@ -40,8 +40,8 @@ class octo_base::cloudwatch::logs (
             "datetime_format" => "%b %d %H:%M:%S",
         },
         {
-            "log_group_name" => "system.dpkg",
-            "path" => "/var/log/dpkg.log",
+            "log_group_name" => "system.apt",
+            "path" => "/var/log/apt/history.log",
             # Eg 2021-03-17 15:53:34
             "datetime_format" => "%Y-%m-%d %H:%M:%S"
         },

--- a/templates/cloudwatch/amazon-cloudwatch-agent.json.erb
+++ b/templates/cloudwatch/amazon-cloudwatch-agent.json.erb
@@ -2,7 +2,8 @@
       "agent": {
         "metrics_collection_interval": 60,
         "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
-        "run_as_user": "cwagent"
+        "run_as_user": "cwagent",
+        "omit_hostname": true
       },
       "metrics": {
         "namespace": "EC2/Custom",
@@ -111,10 +112,7 @@
             }
           ]
         },
-        "append_dimensions": {
-          "InstanceId": "${aws:InstanceId}",
-          "AutoScalingGroupName": "${aws:AutoScalingGroupName}"
-        },
+        "aggregation_dimensions": [["InstanceName"]]
         "force_flush_interval" : 30
       },
       "logs": {

--- a/templates/cloudwatch/amazon-cloudwatch-agent.json.erb
+++ b/templates/cloudwatch/amazon-cloudwatch-agent.json.erb
@@ -1,7 +1,7 @@
     {
       "agent": {
         "metrics_collection_interval": 60,
-        "logfile": "/var/log/amazon-cloudwatch-agent.log",
+        "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
         "run_as_user": "cwagent"
       },
       "metrics": {


### PR DESCRIPTION
Slack thread: https://octoenergy.slack.com/archives/C01FM6D03PX/p1654124019596659

This fixes up the aggregate dimensions, removes the hostname (internal IP) as a dimension, swaps the `dpkg` log with `apt` (CW Agent was erroring that the dpkg log doesn't exist), and changes the CW Agent log location to somewhere the `cwagent` can write to.

I had this running on a good-test support-server and it was working fine (except system load, but that's in the Slack thread):
![image](https://user-images.githubusercontent.com/34290279/171547134-cb6c7a56-eba3-46a7-ad46-7a23510a36b4.png)
