### PR TITLE
Force a dist-upgrade instead of apt-get upgrade

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ class octo_base (
 
     # Apply security patches for installed packages
     exec { "upgrade installed packages":
-        command => "time -p /usr/bin/apt-get -y upgrade --fix-missing --fix-broken --autoremove",
+        command => "time -p /usr/bin/apt-get -y dist-upgrade --fix-missing --fix-broken --autoremove",
         # Use a longer timeout as the default of 300 seconds fails more often than
         # we would like.
         timeout => 600,


### PR DESCRIPTION
The dist-upgrade is a superset of upgrade. Apart from the upgrade function, it can also intelligently handle changes in the package dependencies. This includes removing dependency packages that are no longer necessary or resolving conflicts between packages that arose because of changes in the dependencies.

This should solve most kernel CVEs flagged by Inspector on AMIs built by us (postgres-datadog-agent and others)

https://octoenergy.slack.com/archives/C01FM6D03PX/p1681724253197349

**TESTS**
Using `AWS_REGION_EU_WEST1: "ami-081ff4b9aa4e81a08"` (same we are using atm in octoforce repo as source to launch an AMI in my sandbox account:

running `time -p /usr/bin/apt-get -y upgrade --fix-missing --fix-broken --autoremove` **does not touch** kernel packages:

```
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following packages have been kept back:
  fwupd linux-aws linux-headers-aws linux-image-aws
```

running `time -p /usr/bin/apt-get -y dist-upgrade --fix-missing --fix-broken --autoremove` **does touch** kernel packages:

```
Reading package lists...
Building dependency tree...
Reading state information...
Calculating upgrade...
The following packages will be REMOVED:
  libfwupdplugin1 libxmlb1
The following NEW packages will be installed:
  libfwupdplugin5 libmbim-glib4 libmbim-proxy libmm-glib0 libqmi-glib5
  libqmi-proxy libxmlb2 linux-aws-5.15-headers-5.15.0-1033
  linux-headers-5.15.0-1033-aws linux-image-5.15.0-1033-aws
  linux-modules-5.15.0-1033-aws modemmanager usb-modeswitch
  usb-modeswitch-data
The following packages will be upgraded:
  fwupd linux-aws linux-headers-aws linux-image-aws
```