### PR TITLE
Don't remove snapd from ubuntu 22

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ After any change made to the base manifest, there's three things that need to be
 
 ## Changelog
 
+### v1.45
+
+- Update unnecessary package list to not remove snapd on newer ubuntu images
+
 ### v1.44
 
 - Add puppet tooling

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,16 +17,28 @@ class octo_base (
     logoutput => on_failure,
   }
 
-  # Remove unnecessary packages for Ubuntu 18:04 (see https://peteris.rocks/blog/can-you-kill-it/)
-  $unnecessary_packages = [
-    'snapd',
-    'lvm2',
-    'lxcfs',
-    'accountsservice',
-    'at',
-    'policykit-1',
-    'telnet',
-  ]
+  if $facts['os']['distro']['release']['full'] == '18.04' {
+    # Remove unnecessary packages for Ubuntu 18:04 (see https://peteris.rocks/blog/can-you-kill-it/)
+    $unnecessary_packages = [
+      'snapd',
+      'lvm2',
+      'lxcfs',
+      'accountsservice',
+      'at',
+      'policykit-1',
+      'telnet',
+    ]
+  } else {
+    $unnecessary_packages = [
+      'lvm2',
+      'lxcfs',
+      'accountsservice',
+      'at',
+      'policykit-1',
+      'telnet',
+    ]
+  } 
+
   package { $unnecessary_packages:
     ensure  => 'purged',
     require => Exec['update apt repositories'],

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "octoenergy-octo_base",
-  "version": "1.44",
+  "version": "1.45",
   "author": "Octopus Energy",
   "license": "BSD",
   "summary": "Base machine functionality for Octopus Energy",


### PR DESCRIPTION
[Asana ticket](https://app.asana.com/0/home/1203601404080489/1205441566371099)

ssm runs in snapd, ssm has inspector in it. So to fix the security issues with using ubuntu 18 for the meterpoint service we need snapd to installed versions of ubuntu 20+ so ssm can be installed. 

Linked to this is a [PR](https://github.com/octoenergy/meter-point-data-service/pull/283) in the meter-points-data-service, Which updates dependencies including the new version of this base image. A key change in that PR is telling this base image  to not install aws_inspector as ssm does that for us.
